### PR TITLE
Improve archive notice and redirect to docs.datajoint.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,116 @@
-# DataJoint Specs
+# ⚠️ Repository Archived
 
-> **Notice: Repository Transition**
+> **This repository has been archived and is no longer maintained.**
 >
-> This repository is being archived. The DataJoint Specifications are migrating to [datajoint-docs](https://github.com/datajoint/datajoint-docs) as part of the unified documentation site at [docs.datajoint.com](https://docs.datajoint.com).
+> **All specifications have moved to the unified DataJoint documentation:**
 >
-> **What's changing:**
-> - Specifications → `datajoint-docs/src/reference/specs/`
-> - DSEP process → GitHub Discussions RFC process in [datajoint-python](https://github.com/datajoint/datajoint-python/discussions) and [datajoint-docs](https://github.com/datajoint/datajoint-docs/discussions)
->
-> See the [Contributing Guide](https://docs.datajoint.com/about/contributing/) for the new RFC process.
+> 🔗 **https://docs.datajoint.com/reference/specs/**
 
-## Purpose
+---
 
-This repo manages the DataJoints Specs.
+## Where to Find Content
+
+All specifications from this repository have been migrated to the unified documentation for DataJoint 2.0+:
+
+| Spec Content | New Location |
+|--------------|--------------|
+| **All Specifications** | [Reference/Specs](https://docs.datajoint.com/reference/specs/) |
+| Table Declaration | [Table Declaration Spec](https://docs.datajoint.com/reference/specs/table-declaration/) |
+| Query Algebra | [Query Algebra Spec](https://docs.datajoint.com/reference/specs/query-algebra/) |
+| Type System | [Type System Spec](https://docs.datajoint.com/reference/specs/type-system/) |
+| Data Manipulation | [Data Manipulation Spec](https://docs.datajoint.com/reference/specs/data-manipulation/) |
+| AutoPopulate | [AutoPopulate Spec](https://docs.datajoint.com/reference/specs/autopopulate/) |
+| Codec API | [Codec API Spec](https://docs.datajoint.com/reference/specs/codec-api/) |
+| Semantic Matching | [Semantic Matching Spec](https://docs.datajoint.com/reference/specs/semantic-matching/) |
+
+## What Changed
+
+### Specifications
+- **Location:** Specifications now live in `datajoint-docs/src/reference/specs/`
+- **Format:** Markdown format for better integration with documentation
+- **Version:** Updated for DataJoint 2.0+ baseline
+- **Organization:** Part of unified Reference section
+
+### Enhancement Process
+- **Old:** DSEP (DataJoint-Specs Enhancement Proposals) process **[Deprecated]**
+- **New:** RFC (Request for Comments) via GitHub Discussions
+  - [datajoint-python Discussions](https://github.com/datajoint/datajoint-python/discussions)
+  - [datajoint-docs Discussions](https://github.com/datajoint/datajoint-docs/discussions)
+
+See the [Contributing Guide](https://docs.datajoint.com/about/contributing/) for the new RFC process.
+
+## New Documentation Structure
+
+The DataJoint documentation follows the [Diátaxis](https://diataxis.fr/) framework:
+
+- **[Tutorials](https://docs.datajoint.com/tutorials/)** — Learn by building
+- **[How-To Guides](https://docs.datajoint.com/how-to/)** — Task-oriented guides
+- **[Explanation](https://docs.datajoint.com/explanation/)** — Concepts and design
+- **[Reference](https://docs.datajoint.com/reference/)** — Specifications and API (replaces this repo)
+
+## Purpose of DataJoint Specs
 
 The **DataJoint Specs** establish the **standards, conventions, and best practices** for designing and managing **DataJoint pipelines**.
-These specifications ensure **consistency, scalability, and interoperability** across different scientific workflows and computing environments.  
+These specifications ensure **consistency, scalability, and interoperability** across different scientific workflows and computing environments.
 
-By following the **DataJoint Specs**, users and developers can:  
-- Maintain **structured, reproducible data pipelines**.  
-- Ensure **compatibility across different DataJoint implementations**.  
-- Adopt **best practices** for schema design, data integrity, and computational workflows.  
-- Provide a **foundation for future enhancements** while preserving backward compatibility.  
+By following the **DataJoint Specs**, users and developers can:
+- Maintain **structured, reproducible data pipelines**
+- Ensure **compatibility across different DataJoint implementations**
+- Adopt **best practices** for schema design, data integrity, and computational workflows
+- Provide a **foundation for future enhancements** while preserving backward compatibility
+
+## Communicating Version Compatibility
+
+DataJoint Specs evolve **independently** from **DataJoint implementations**.
+
+- Each implementation release states the spec version it supports
+- Spec releases include a compatibility table listing compliant implementations
+- Deprecations and upcoming changes are announced in advance to allow for smooth adoption
+
+Each implementation **aligns with a specific spec version**, ensuring compliance while allowing for **gradual adoption of new features**.
+
+Example:
+```
+DataJoint Python v2.0.0 - Supports Spec v2.0
+- Introduces unified stores configuration
+- Redesigned fetch API
+```
+
+## Contributing
+
+Contributions now go through the unified documentation repository:
+
+- **Documentation:** [github.com/datajoint/datajoint-docs](https://github.com/datajoint/datajoint-docs)
+- **Contributing Guide:** [docs.datajoint.com/about/contributing](https://docs.datajoint.com/about/contributing/)
+- **Discussion (RFC):** [GitHub Discussions](https://github.com/datajoint/datajoint-python/discussions)
+
+### Proposing Specification Changes
+
+1. Open a **Discussion** in [datajoint-python](https://github.com/datajoint/datajoint-python/discussions) with `[RFC]` prefix
+2. Discuss with community and maintainers
+3. If accepted, submit a PR to [datajoint-docs](https://github.com/datajoint/datajoint-docs)
+4. Specifications are updated in `src/reference/specs/`
+
+## Migration to DataJoint 2.0
+
+If you're using DataJoint 0.14.x or earlier:
+
+📖 See the [Migration Guide](https://docs.datajoint.com/how-to/migrate-to-v20/)
+
+For pre-2.0 documentation, visit [datajoint.github.io/datajoint-python](https://datajoint.github.io/datajoint-python).
 
 ## License
+
 This project, including the DataJoint Specification document, is licensed under the [CC BY-SA 4.0 License](LICENSE.md).
 
+## Support
 
-## Communicating version compatibility
-DataJoint Specs evolve **independently** from **DataJoint implementations** 
+- **Documentation:** https://docs.datajoint.com
+- **Community:** [GitHub Discussions](https://github.com/datajoint/datajoint-python/discussions)
+- **Issues:** [datajoint-docs issues](https://github.com/datajoint/datajoint-docs/issues)
+- **Email:** support@datajoint.com
 
-* Each implementation release states the spec version it supports.
-* Spec releases include a compatibility table listing compliant implementations.
-* Deprecations and upcoming changes are announced in advance to allow for smooth adoption.
+---
 
-Each implementation **aligns with a specific spec version**, ensuring compliance while allowing for **gradual adoption of new features**.  
-
-Each implementation release may claim which Specs verrsion it supports. For example: 
-```
-# DataJoint Python v1.2.0 - Supports Spec v2.2
-- Backward-compatible with Spec v2.1.
-```
-
-## Specifications
-- **[Version 2.0](SPECS_2_0.md)** – Accepted 2025-06-01
-- **[Version 2.1](SPECS_2_1.md)** – Draft (Estimated Acceptance: 2025-09-01)
-
-## DataJoint-Specs Enhancement Proposals (DSEPs)
-
-> **Deprecated:** The DSEP process is being replaced by GitHub Discussions RFCs.
-> See the [Contributing Guide](https://docs.datajoint.com/about/contributing/) for the new process.
-
-* [DSEP Process](DSEP_process.md) *(deprecated)*
-* DSEP Template [DSEP-xxx](DSEP/DSEP-xxx.md) *(deprecated)*
+**Last Updated:** January 2026
+**Archive Date:** January 2026


### PR DESCRIPTION
## Changes

This PR improves the existing transition notice to be more prominent and comprehensive, redirecting users to the unified documentation at docs.datajoint.com/reference/specs/.

### Improved Archive Notice

- Prominent warning at top of README (matching other archived repos)
- Clear redirect to https://docs.datajoint.com/reference/specs/

### Comprehensive Content Mapping

Detailed table showing where to find each specification:
- Table Declaration → Reference/Specs/Table Declaration
- Query Algebra → Reference/Specs/Query Algebra
- Type System → Reference/Specs/Type System
- Data Manipulation → Reference/Specs/Data Manipulation
- AutoPopulate → Reference/Specs/AutoPopulate
- Codec API → Reference/Specs/Codec API
- Semantic Matching → Reference/Specs/Semantic Matching

### What Changed Section

- Specifications location and format
- DSEP → RFC process transition
- Links to new RFC discussion locations

### RFC Process Documentation

Clear instructions for proposing specification changes:
1. Open Discussion in datajoint-python with [RFC] prefix
2. Discuss with community
3. Submit PR to datajoint-docs
4. Specifications updated in src/reference/specs/

### Other Information

- Purpose and version compatibility sections preserved
- Migration guide link for legacy users
- Contributing instructions for new docs repo
- License preserved
- Support links

## Rationale

This repo already had a transition notice, but it needed to be more prominent and comprehensive to match the style of the other archived repos (datajoint-tutorials, datajoint-book).

All specifications have been migrated to the unified documentation repository (datajoint-docs) and updated for DataJoint 2.0. This repository is no longer maintained.

## Next Steps

After merge:
1. Archive the repository on GitHub
2. Update repository description to redirect to docs.datajoint.com
3. Add archived badge to repository